### PR TITLE
remove compiler warning about fread return value

### DIFF
--- a/src/demos/showpng.c
+++ b/src/demos/showpng.c
@@ -53,7 +53,10 @@ void read_png_file(char* file_name)
 	if (!fp)
 		abort_("[read_png_file] File %s could not be opened for reading", file_name);
 	
-	fread(header, 1, 8, fp);
+	if ( 8!=fread(header, 1, 8, fp) )
+        abort_("[read_png_file] File %s could not read PNG signature bytes", file_name);
+	
+
 	
 	if (png_sig_cmp(header, 0, 8))
 		abort_("[read_png_file] File %s is not recognized as a PNG file", file_name);


### PR DESCRIPTION
The default compilig showpng.c will show the warning

```c
showpng.c: In function ‘read_png_file’:
showpng.c:55:5: warning: ignoring return value of ‘fread’, declared with attribute warn_unus
ed_result [-Wunused-result]
     fread(header, 1, 8 , fp); 
```
this patch will remove the warning 
By the way, this is a useful library.
